### PR TITLE
Fix type errors in ballot/ui

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -44,9 +44,11 @@ export const App: FC = observer(() => {
         } else {
           // use your current ship booth since we didnt find the url booth
           store.setBooth(app.ship.patp);
-          let newPath = createPath(store.booth!.key, app.currentPage);
-          navigate(newPath);
-          app.setCurrentUrl(newPath, app.currentPage);
+          if (store.booth?.key) {
+            const newPath = createPath(store.booth.key, app.currentPage);
+            navigate(newPath);
+            app.setCurrentUrl(newPath, app.currentPage);
+          }
           return;
         }
       }),

--- a/ui/src/logic/stores/booths/booth.ts
+++ b/ui/src/logic/stores/booths/booth.ts
@@ -137,7 +137,7 @@ export const BoothModel = types
         const participant: ParticipantModelType =
           self.participantStore.participants.get(rootStore.app.ship.patp);
 
-        if (self.permissions.includes(participant.role)) {
+        if (self.permissions.includes(participant?.role)) {
           return true;
         } else {
           return false;
@@ -155,7 +155,7 @@ export const BoothModel = types
           self.participantStore.participants.get(rootStore.app.ship.patp);
         if (
           self.permissions.includes("admin") &&
-          participant.role === "admin"
+          participant?.role === "admin"
         ) {
           return true;
         }


### PR DESCRIPTION
This is more of a heads-up, you might not want to merge this.

But I encountered 3 type errors when booting ballot/ui locally without any data hydration.

This is simply adding some optional chaining – I'd probably try to sort out the `ParticipantModelType` if I had more context (it's currently typed as `any`).

The errors:

<img width="613" alt="typeerror1" src="https://user-images.githubusercontent.com/29574724/199344004-34764032-8b4d-4d54-ba67-b9e632ef6a2c.png">
<img width="441" alt="typeerror2" src="https://user-images.githubusercontent.com/29574724/199344008-e295fcbd-7ddf-4c15-9732-7d5da561d2a2.png">
<img width="441" alt="typeerror3" src="https://user-images.githubusercontent.com/29574724/199344010-9882b5cf-233c-47be-ae34-6d781d91a8ce.png">
